### PR TITLE
Update mt7986a-asus-tuf-ax6000.dts to fix issue 15304

### DIFF
--- a/target/linux/mediatek/dts/mt7986a-asus-tuf-ax6000.dts
+++ b/target/linux/mediatek/dts/mt7986a-asus-tuf-ax6000.dts
@@ -298,25 +298,25 @@
 		port@1 {
 			reg = <4>;
 			label = "lan1";
-			phy-handle = <&swphy1>;
+			phy-handle = <&swphy4>;
 		};
 
 		port@2 {
 			reg = <3>;
 			label = "lan2";
-			phy-handle = <&swphy2>;
+			phy-handle = <&swphy3>;
 		};
 
 		port@3 {
 			reg = <2>;
 			label = "lan3";
-			phy-handle = <&swphy3>;
+			phy-handle = <&swphy2>;
 		};
 
 		port@4 {
 			reg = <1>;
 			label = "lan4";
-			phy-handle = <&swphy4>;
+			phy-handle = <&swphy1>;
 		};
 
 		port@5 {


### PR DESCRIPTION
To fix issue 15304 Wrong br-lan port 1-4 numbering
